### PR TITLE
chore: Test docker publish work flow failing on amd64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,7 +76,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
Docker publish failing at https://github.com/newrelic/ansible-runner/actions/runs/8927381323/job/24675220071 with this error. 

This PR has been raised to test the docker publish on arm platform.

```
#14 [linux/amd64 6/9] RUN pipx install --include-deps ansible
[586](https://github.com/newrelic/ansible-runner/actions/runs/8927381323/job/24675220071#step:9:591)
#14 32.15 ⚠️  Note: '/root/.local/bin' is not on your PATH environment variable. These
[587](https://github.com/newrelic/ansible-runner/actions/runs/8927381323/job/24675220071#step:9:592)
#14 32.15     apps will not be globally accessible until your PATH is updated. Run `pipx
[588](https://github.com/newrelic/ansible-runner/actions/runs/8927381323/job/24675220071#step:9:593)
#14 32.15     ensurepath` to automatically add it, or manually modify your PATH in your
[589](https://github.com/newrelic/ansible-runner/actions/runs/8927381323/job/24675220071#step:9:594)
#14 32.15     shell's config file (i.e. ~/.bashrc).
```