### PR TITLE
chore: bump up cosign version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,9 +31,9 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
+        uses: sigstore/cosign-installer@v3.5.0
         with:
-          cosign-release: 'v2.1.1'
+          cosign-release: 'v2.2.4'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
This PR has been raised to address the fix with signing the published docker image https://github.com/newrelic/ansible-runner/actions/runs/8987800792/job/24687160221.

References - 

https://blog.sigstore.dev/tuf-root-update/ 
https://github.com/sigstore/cosign/issues/3614 
https://github.com/sigstore/cosign-installer 